### PR TITLE
Add AppError utility package

### DIFF
--- a/backend/internal/pkg/errors/errors.go
+++ b/backend/internal/pkg/errors/errors.go
@@ -1,0 +1,34 @@
+package errors
+
+// AppError represents a structured application error.
+type AppError struct {
+	Code    string
+	Message string
+	Status  int
+	Details map[string]any
+}
+
+// Error implements the error interface.
+func (e *AppError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+// New creates a new AppError without details.
+func New(code, message string, status int) *AppError {
+	return &AppError{Code: code, Message: message, Status: status}
+}
+
+// NewWithDetails creates a new AppError with additional detail data.
+func NewWithDetails(code, message string, status int, details map[string]any) *AppError {
+	return &AppError{Code: code, Message: message, Status: status, Details: details}
+}
+
+var (
+	// ErrUserNotFound is returned when a user cannot be located.
+	ErrUserNotFound = New("user_not_found", "user not found", 404)
+	// ErrInvalidInput indicates invalid client supplied data.
+	ErrInvalidInput = New("invalid_input", "invalid input", 400)
+)

--- a/backend/internal/pkg/errors/errors_test.go
+++ b/backend/internal/pkg/errors/errors_test.go
@@ -1,0 +1,36 @@
+package errors
+
+import "testing"
+
+func TestNew(t *testing.T) {
+	e := New("c", "msg", 500)
+	if e.Code != "c" || e.Message != "msg" || e.Status != 500 {
+		t.Fatalf("unexpected AppError: %+v", e)
+	}
+	if e.Details != nil {
+		t.Fatalf("expected nil details")
+	}
+	if e.Error() != "msg" {
+		t.Fatalf("expected error message 'msg', got %q", e.Error())
+	}
+}
+
+func TestNewWithDetails(t *testing.T) {
+	d := map[string]any{"foo": "bar"}
+	e := NewWithDetails("c", "msg", 400, d)
+	if e.Code != "c" || e.Message != "msg" || e.Status != 400 {
+		t.Fatalf("unexpected AppError: %+v", e)
+	}
+	if e.Details["foo"] != "bar" {
+		t.Fatalf("expected details to contain foo=bar")
+	}
+}
+
+func TestCommonErrors(t *testing.T) {
+	if ErrUserNotFound.Status != 404 {
+		t.Errorf("expected 404 status")
+	}
+	if ErrInvalidInput.Status != 400 {
+		t.Errorf("expected 400 status")
+	}
+}


### PR DESCRIPTION
## Summary
- add `AppError` struct with helper constructors and common error vars
- add tests for `AppError` behavior

## Testing
- `go test ./internal/pkg/errors`

------
https://chatgpt.com/codex/tasks/task_e_684b96e52bfc832fa5ae53d58985a5b4