### PR TITLE
Add DeepSeek client skeleton

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,23 +1,20 @@
 package main
 
 import (
-
 	"fmt"
 	"log"
 
 	"alchemorsel/backend/internal/config"
 	httpserver "alchemorsel/backend/internal/interfaces/http"
-
 )
 
 func main() {
 	cfg := config.Load()
 
-
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
 	log.Printf("Starting server on %s", addr)
-	if err := router.Run(addr); err != nil {
-
+	r := httpserver.SetupRouter()
+	if err := r.Run(addr); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/backend/internal/domain/user/entity.go
+++ b/backend/internal/domain/user/entity.go
@@ -1,6 +1,5 @@
 package user
 
-
 import (
 	"time"
 
@@ -20,3 +19,4 @@ type User struct {
 	CreatedAt          time.Time  `json:"created_at"`
 	UpdatedAt          time.Time  `json:"updated_at"`
 	DeletedAt          *time.Time `json:"deleted_at,omitempty"`
+}

--- a/backend/internal/infrastructure/external/deepseek/client.go
+++ b/backend/internal/infrastructure/external/deepseek/client.go
@@ -1,0 +1,31 @@
+package deepseek
+
+import (
+	"context"
+	"net/http"
+
+	"alchemorsel/backend/internal/domain/recipe"
+)
+
+// Client provides access to the DeepSeek API.
+type Client struct {
+	apiKey     string
+	apiURL     string
+	httpClient *http.Client
+}
+
+// GenerateRecipeRequest defines parameters for recipe generation.
+type GenerateRecipeRequest struct {
+	UserPreferences   any
+	RecipeConstraints any
+	Style             string
+}
+
+// GenerateRecipe generates a recipe using the DeepSeek API.
+func (c *Client) GenerateRecipe(ctx context.Context, req GenerateRecipeRequest) (*recipe.Recipe, error) {
+	// TODO: create prompt based on request
+	// TODO: call DeepSeek API
+	// TODO: parse response into recipe entity
+	// TODO: generate embeddings
+	return nil, nil
+}


### PR DESCRIPTION
## Summary
- stub DeepSeek client in infrastructure layer
- fix compile errors in user entity and API main

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684b96daf378832f80fd27186ce1d714