### PR TITLE
Add HTTP middleware and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ go run ./cmd/api
 
 
 The server exposes a versioned API under `/api/v1`. Only a simple health check is implemented but the router already includes endpoints for authentication, user profiles and recipes as described in the design docs.
+The router also applies placeholder middleware for authentication, CORS, logging, and panic recovery.
 
 ### Frontend
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,23 +1,21 @@
 package main
 
 import (
-
 	"fmt"
 	"log"
 
 	"alchemorsel/backend/internal/config"
 	httpserver "alchemorsel/backend/internal/interfaces/http"
-
 )
 
 func main() {
 	cfg := config.Load()
 
-
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
 	log.Printf("Starting server on %s", addr)
-	if err := router.Run(addr); err != nil {
 
+	router := httpserver.SetupRouter()
+	if err := router.Run(addr); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/backend/internal/domain/user/entity.go
+++ b/backend/internal/domain/user/entity.go
@@ -1,6 +1,5 @@
 package user
 
-
 import (
 	"time"
 
@@ -20,3 +19,4 @@ type User struct {
 	CreatedAt          time.Time  `json:"created_at"`
 	UpdatedAt          time.Time  `json:"updated_at"`
 	DeletedAt          *time.Time `json:"deleted_at,omitempty"`
+}

--- a/backend/internal/interfaces/http/middleware/auth.go
+++ b/backend/internal/interfaces/http/middleware/auth.go
@@ -1,0 +1,14 @@
+package middleware
+
+import "github.com/gin-gonic/gin"
+
+// Auth extracts the Authorization header and stores user info in the context.
+// In this placeholder implementation the header value itself is stored.
+func Auth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if auth := c.GetHeader("Authorization"); auth != "" {
+			c.Set("user", auth)
+		}
+		c.Next()
+	}
+}

--- a/backend/internal/interfaces/http/middleware/cors.go
+++ b/backend/internal/interfaces/http/middleware/cors.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CORS sets simple CORS headers for every request.
+func CORS() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Access-Control-Allow-Origin", "*")
+		c.Header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
+		c.Header("Access-Control-Allow-Headers", "Authorization,Content-Type")
+
+		if c.Request.Method == http.MethodOptions {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/backend/internal/interfaces/http/middleware/logging.go
+++ b/backend/internal/interfaces/http/middleware/logging.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"log"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Logging logs request method, path and duration.
+func Logging() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		method := c.Request.Method
+		path := c.Request.URL.Path
+
+		c.Next()
+
+		duration := time.Since(start)
+		log.Printf("%s %s %v", method, path, duration)
+	}
+}

--- a/backend/internal/interfaces/http/middleware/recovery.go
+++ b/backend/internal/interfaces/http/middleware/recovery.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Recovery recovers from panics and returns a 500 error.
+func Recovery() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("panic recovered: %v", r)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			}
+		}()
+
+		c.Next()
+	}
+}

--- a/backend/internal/interfaces/http/middleware/recovery_test.go
+++ b/backend/internal/interfaces/http/middleware/recovery_test.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestRecovery ensures that the middleware converts panics to 500 errors.
+func TestRecovery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(Recovery())
+	r.GET("/panic", func(c *gin.Context) {
+		panic("boom")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if expected := "internal server error"; !strings.Contains(w.Body.String(), expected) {
+		t.Fatalf("expected body to contain %q, got %s", expected, w.Body.String())
+	}
+}

--- a/backend/internal/interfaces/http/router.go
+++ b/backend/internal/interfaces/http/router.go
@@ -3,13 +3,14 @@ package http
 import (
 	"github.com/gin-gonic/gin"
 
-
 	"alchemorsel/backend/internal/interfaces/http/handlers"
+	"alchemorsel/backend/internal/interfaces/http/middleware"
 )
 
 // SetupRouter configures all HTTP routes following the design docs.
 func SetupRouter() *gin.Engine {
-	r := gin.Default()
+	r := gin.New()
+	r.Use(middleware.Recovery(), middleware.Logging(), middleware.CORS())
 
 	api := r.Group("/api/v1")
 	{
@@ -22,8 +23,9 @@ func SetupRouter() *gin.Engine {
 			auth.POST("/refresh", handlers.RefreshToken)
 		}
 
-		// Protected routes – authentication middleware would be added here.
+		// Protected routes require authentication middleware.
 		protected := api.Group("")
+		protected.Use(middleware.Auth())
 		{
 			users := protected.Group("/users")
 			{
@@ -44,7 +46,6 @@ func SetupRouter() *gin.Engine {
 			protected.POST("/llm/generate", handlers.GenerateRecipe)
 		}
 	}
-
 
 	return r
 }


### PR DESCRIPTION
## Summary
- add placeholder middleware for Auth, CORS, Logging and Recovery
- hook middleware into router and fix `cmd/api` main
- close struct in user entity to fix build
- provide a recovery middleware test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b96e6b818832fa406c34314c0f748