### PR TITLE
Add env template, Makefile and docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+APP_HOST=0.0.0.0
+APP_PORT=8080
+
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=alchemorsel
+DB_SSLMODE=disable
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: run test
+
+run:
+	cd backend && go run ./cmd/api
+
+test:
+	cd backend && go test ./...

--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ npm run dev
 
 Then open `http://localhost:5173`.
 
+### Configuration
+
+Copy `.env.example` to `.env` and adjust any of the values if needed. The
+backend reads these variables when starting up.
+
+### Makefile
+
+Common commands are wrapped in a simple `Makefile`. From the project root you
+can run:
+
+```bash
+make run  # start the API server
+make test # run backend tests
+```
+
+### Docker Compose
+
+`docker-compose.yml` launches the API together with PostgreSQL and Redis. Start
+all services with:
+
+```bash
+docker-compose up
+```
+
 ## Documentation
 
 Please refer to the markdown files such as `system-overview.md` and `implementation-order.md` for a detailed description of the architecture, API design, and testing approach.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.9'
+services:
+  api:
+    image: golang:1.23
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    command: go run ./cmd/api
+    environment:
+      APP_HOST: 0.0.0.0
+      APP_PORT: 8080
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: alchemorsel
+      DB_SSLMODE: disable
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+      - redis
+
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: alchemorsel
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
## Summary
- provide `.env.example` with server and DB vars
- add a simple Makefile with `run` and `test` helpers
- create `docker-compose.yml` with API, PostgreSQL and Redis services
- document setup and usage of the new files in the README

## Testing
- `go test ./...`
- `make test`
- `timeout 5 make run` (server started then timed out)

------
https://chatgpt.com/codex/tasks/task_e_684ba1e17de8832f9f53888b2be86ac7