### PR TITLE
Add structured logging and request ID middleware

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -2,22 +2,20 @@ package main
 
 import (
 	"fmt"
-	"log"
 
 	"alchemorsel/backend/internal/config"
 	httpserver "alchemorsel/backend/internal/interfaces/http"
+	"alchemorsel/backend/internal/pkg/logger"
 )
 
 func main() {
 	cfg := config.Load()
 
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
-	log.Printf("Starting server on %s", addr)
-
+	logger.Infof("Starting server on %s", addr)
 
 	router := httpserver.SetupRouter()
 	if err := router.Run(addr); err != nil {
-
-		log.Fatal(err)
+		logger.Fatal(err)
 	}
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
+	go.uber.org/zap v1.27.0
 )
 
 require (
@@ -28,6 +29,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/net v0.25.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -67,6 +67,12 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.8.0 h1:3wRIsP3pM4yUptoR96otTUOXI367OS0+c9eeRi9doIc=
 golang.org/x/arch v0.8.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=

--- a/backend/internal/interfaces/http/middleware/logging.go
+++ b/backend/internal/interfaces/http/middleware/logging.go
@@ -1,22 +1,27 @@
 package middleware
 
 import (
-	"log"
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"alchemorsel/backend/internal/pkg/logger"
 )
 
 // Logging logs request method, path and duration.
 func Logging() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
-		method := c.Request.Method
-		path := c.Request.URL.Path
 
 		c.Next()
 
 		duration := time.Since(start)
-		log.Printf("%s %s %v", method, path, duration)
+
+		l := logger.FromContext(c.Request.Context())
+		l.Infow("request completed",
+			"method", c.Request.Method,
+			"path", c.Request.URL.Path,
+			"duration", duration.String(),
+		)
 	}
 }

--- a/backend/internal/interfaces/http/middleware/recovery.go
+++ b/backend/internal/interfaces/http/middleware/recovery.go
@@ -1,10 +1,11 @@
 package middleware
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
+	"alchemorsel/backend/internal/pkg/logger"
 )
 
 // Recovery recovers from panics and returns a 500 error.
@@ -12,7 +13,7 @@ func Recovery() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		defer func() {
 			if r := recover(); r != nil {
-				log.Printf("panic recovered: %v", r)
+				logger.FromContext(c.Request.Context()).Errorf("panic recovered: %v", r)
 				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			}
 		}()

--- a/backend/internal/interfaces/http/middleware/requestid.go
+++ b/backend/internal/interfaces/http/middleware/requestid.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"alchemorsel/backend/internal/pkg/logger"
+)
+
+// RequestIDKey is the gin context key storing the request id.
+const RequestIDKey = "request_id"
+
+// RequestID injects a unique request ID into the context and response headers.
+func RequestID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := uuid.New().String()
+		c.Set(RequestIDKey, id)
+		c.Writer.Header().Set("X-Request-ID", id)
+
+		l := logger.Logger().With("request_id", id)
+		c.Request = c.Request.WithContext(logger.ToContext(c.Request.Context(), l))
+
+		c.Next()
+	}
+}

--- a/backend/internal/interfaces/http/middleware/requestid_test.go
+++ b/backend/internal/interfaces/http/middleware/requestid_test.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"alchemorsel/backend/internal/pkg/logger"
+)
+
+func TestRequestID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger.SetLogger(zap.NewNop().Sugar())
+
+	r := gin.New()
+	r.Use(RequestID())
+	r.GET("/", func(c *gin.Context) {
+		id := c.GetString(RequestIDKey)
+		if id == "" {
+			t.Errorf("request id missing from context")
+		}
+		l := logger.FromContext(c.Request.Context())
+		if l == nil {
+			t.Errorf("logger missing from context")
+		}
+		c.String(http.StatusOK, id)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	id := w.Header().Get("X-Request-ID")
+	if id == "" {
+		t.Fatalf("X-Request-ID header missing")
+	}
+	if w.Body.String() != id {
+		t.Fatalf("handler saw id %s, header %s", w.Body.String(), id)
+	}
+
+	// second request should receive a different id
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	id2 := w2.Header().Get("X-Request-ID")
+	if id2 == id {
+		t.Fatalf("expected unique request id, got %s twice", id)
+	}
+}

--- a/backend/internal/interfaces/http/router.go
+++ b/backend/internal/interfaces/http/router.go
@@ -10,7 +10,12 @@ import (
 // SetupRouter configures all HTTP routes following the design docs.
 func SetupRouter() *gin.Engine {
 	r := gin.New()
-	r.Use(middleware.Recovery(), middleware.Logging(), middleware.CORS())
+	r.Use(
+		middleware.Recovery(),
+		middleware.RequestID(),
+		middleware.Logging(),
+		middleware.CORS(),
+	)
 
 	api := r.Group("/api/v1")
 	{

--- a/backend/internal/pkg/logger/logger.go
+++ b/backend/internal/pkg/logger/logger.go
@@ -1,0 +1,69 @@
+package logger
+
+import (
+	"context"
+	"go.uber.org/zap"
+)
+
+// ctxKey is the type used for storing the logger in a context.Context.
+type ctxKey struct{}
+
+var (
+	key  ctxKey
+	base *zap.SugaredLogger
+)
+
+func init() {
+	Init()
+}
+
+// Init initializes the base logger.
+func Init() {
+	l, err := zap.NewProduction()
+	if err != nil {
+		panic(err)
+	}
+	base = l.Sugar()
+}
+
+// SetLogger replaces the underlying logger. Mainly used for tests.
+func SetLogger(l *zap.SugaredLogger) {
+	base = l
+}
+
+// Logger returns the base logger instance.
+func Logger() *zap.SugaredLogger {
+	return base
+}
+
+// FromContext returns the request-scoped logger stored in the context. If none
+// is found, the base logger is returned.
+func FromContext(ctx context.Context) *zap.SugaredLogger {
+	if ctx == nil {
+		return base
+	}
+	if l, ok := ctx.Value(key).(*zap.SugaredLogger); ok {
+		return l
+	}
+	return base
+}
+
+// ToContext stores the given logger in the context and returns the new context.
+func ToContext(ctx context.Context, l *zap.SugaredLogger) context.Context {
+	return context.WithValue(ctx, key, l)
+}
+
+// Infof logs an informational message using the base logger.
+func Infof(format string, args ...any) {
+	base.Infof(format, args...)
+}
+
+// Errorf logs an error message using the base logger.
+func Errorf(format string, args ...any) {
+	base.Errorf(format, args...)
+}
+
+// Fatal logs a fatal error message and exits.
+func Fatal(err error) {
+	base.Fatal(err)
+}


### PR DESCRIPTION
## Summary
- wrap zap in a new logger package
- add request ID middleware and logging integration
- switch main program to use logger
- log through zap in middleware
- test request ID middleware

## Testing
- `go test ./...`
- `go test ./internal/interfaces/http/middleware -run RequestID -v`

------
https://chatgpt.com/codex/tasks/task_e_684ba1e59bc8832fa13b81e651ac31d5