### PR TITLE
Add DeepSeek client implementation with tests

### DIFF
--- a/backend/internal/infrastructure/external/deepseek/client.go
+++ b/backend/internal/infrastructure/external/deepseek/client.go
@@ -1,8 +1,13 @@
 package deepseek
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"alchemorsel/backend/internal/domain/recipe"
 )
@@ -22,10 +27,71 @@ type GenerateRecipeRequest struct {
 }
 
 // GenerateRecipe generates a recipe using the DeepSeek API.
-func (c *Client) GenerateRecipe(ctx context.Context, req GenerateRecipeRequest) (*recipe.Recipe, error) {
-	// TODO: create prompt based on request
-	// TODO: call DeepSeek API
-	// TODO: parse response into recipe entity
-	// TODO: generate embeddings
-	return nil, nil
+func (c *Client) GenerateRecipe(ctx context.Context, req GenerateRecipeRequest) (*recipe.Recipe, []float64, error) {
+	prompt, err := buildPrompt(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	payloadBytes, err := json.Marshal(map[string]string{"prompt": prompt})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(c.apiURL, "/")+"/generate", bytes.NewReader(payloadBytes))
+	if err != nil {
+		return nil, nil, err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, nil, fmt.Errorf("deepseek: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var dsResp struct {
+		Recipe    recipe.Recipe `json:"recipe"`
+		Embedding []float64     `json:"embedding"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&dsResp); err != nil {
+		return nil, nil, err
+	}
+
+	return &dsResp.Recipe, dsResp.Embedding, nil
+}
+
+func buildPrompt(req GenerateRecipeRequest) (string, error) {
+	b := &strings.Builder{}
+	if req.Style != "" {
+		b.WriteString("Style: ")
+		b.WriteString(req.Style)
+		b.WriteString(". ")
+	}
+	if req.UserPreferences != nil {
+		prefs, err := json.Marshal(req.UserPreferences)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString("Preferences: ")
+		b.Write(prefs)
+		b.WriteString(". ")
+	}
+	if req.RecipeConstraints != nil {
+		cons, err := json.Marshal(req.RecipeConstraints)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString("Constraints: ")
+		b.Write(cons)
+		b.WriteString(". ")
+	}
+	b.WriteString("Generate a recipe.")
+	return b.String(), nil
 }

--- a/backend/internal/infrastructure/external/deepseek/client_test.go
+++ b/backend/internal/infrastructure/external/deepseek/client_test.go
@@ -1,0 +1,60 @@
+package deepseek
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGenerateRecipe(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/generate" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test" {
+			t.Fatalf("unexpected auth header: %s", auth)
+		}
+		var payload struct {
+			Prompt string `json:"prompt"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if !strings.Contains(payload.Prompt, "Style: italian") {
+			t.Fatalf("prompt missing style: %s", payload.Prompt)
+		}
+		resp := map[string]any{
+			"recipe":    map[string]any{"title": "Caprese"},
+			"embedding": []float64{1, 2, 3},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	c := Client{apiKey: "test", apiURL: ts.URL, httpClient: ts.Client()}
+	rec, emb, err := c.GenerateRecipe(context.Background(), GenerateRecipeRequest{Style: "italian"})
+	if err != nil {
+		t.Fatalf("GenerateRecipe returned error: %v", err)
+	}
+	if rec.Title != "Caprese" {
+		t.Fatalf("unexpected recipe title: %s", rec.Title)
+	}
+	if len(emb) != 3 || emb[0] != 1 {
+		t.Fatalf("unexpected embeddings: %v", emb)
+	}
+}
+
+func TestGenerateRecipe_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	c := Client{apiKey: "k", apiURL: ts.URL, httpClient: ts.Client()}
+	if _, _, err := c.GenerateRecipe(context.Background(), GenerateRecipeRequest{}); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- implement prompt builder and DeepSeek client logic
- add tests covering API interactions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ba1e72aec832fac63d4da6a4d8e37