### PR TITLE
Add tests for config loading and middleware

### DIFF
--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadDefaults(t *testing.T) {
+	os.Unsetenv("APP_HOST")
+	os.Unsetenv("APP_PORT")
+	os.Unsetenv("DB_HOST")
+	os.Unsetenv("DB_PORT")
+	os.Unsetenv("DB_USER")
+	os.Unsetenv("DB_PASSWORD")
+	os.Unsetenv("DB_NAME")
+	os.Unsetenv("DB_SSLMODE")
+
+	cfg := Load()
+
+	if cfg.Server.Host != "0.0.0.0" {
+		t.Errorf("expected default host 0.0.0.0, got %s", cfg.Server.Host)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("expected default port 8080, got %d", cfg.Server.Port)
+	}
+	if cfg.Database.Host != "localhost" {
+		t.Errorf("expected default db host localhost, got %s", cfg.Database.Host)
+	}
+	if cfg.Database.Port != 5432 {
+		t.Errorf("expected default db port 5432, got %d", cfg.Database.Port)
+	}
+	if cfg.Database.User != "postgres" {
+		t.Errorf("expected default db user postgres, got %s", cfg.Database.User)
+	}
+	if cfg.Database.Password != "" {
+		t.Errorf("expected default db password empty, got %s", cfg.Database.Password)
+	}
+	if cfg.Database.Name != "alchemorsel" {
+		t.Errorf("expected default db name alchemorsel, got %s", cfg.Database.Name)
+	}
+	if cfg.Database.SSLMode != "disable" {
+		t.Errorf("expected default sslmode disable, got %s", cfg.Database.SSLMode)
+	}
+}
+
+func TestLoadEnvOverrides(t *testing.T) {
+	os.Setenv("APP_HOST", "1.2.3.4")
+	os.Setenv("APP_PORT", "9000")
+	os.Setenv("DB_HOST", "dbhost")
+	os.Setenv("DB_PORT", "notint")
+	os.Setenv("DB_USER", "bob")
+	os.Setenv("DB_PASSWORD", "secret")
+	os.Setenv("DB_NAME", "mydb")
+	os.Setenv("DB_SSLMODE", "require")
+	defer func() {
+		os.Unsetenv("APP_HOST")
+		os.Unsetenv("APP_PORT")
+		os.Unsetenv("DB_HOST")
+		os.Unsetenv("DB_PORT")
+		os.Unsetenv("DB_USER")
+		os.Unsetenv("DB_PASSWORD")
+		os.Unsetenv("DB_NAME")
+		os.Unsetenv("DB_SSLMODE")
+	}()
+
+	cfg := Load()
+
+	if cfg.Server.Host != "1.2.3.4" {
+		t.Errorf("expected host 1.2.3.4, got %s", cfg.Server.Host)
+	}
+	if cfg.Server.Port != 9000 {
+		t.Errorf("expected port 9000, got %d", cfg.Server.Port)
+	}
+	if cfg.Database.Host != "dbhost" {
+		t.Errorf("expected db host dbhost, got %s", cfg.Database.Host)
+	}
+	// DB_PORT is not int so should fall back to default 5432
+	if cfg.Database.Port != 5432 {
+		t.Errorf("expected db port 5432 due to fallback, got %d", cfg.Database.Port)
+	}
+	if cfg.Database.User != "bob" {
+		t.Errorf("expected db user bob, got %s", cfg.Database.User)
+	}
+	if cfg.Database.Password != "secret" {
+		t.Errorf("expected db password secret, got %s", cfg.Database.Password)
+	}
+	if cfg.Database.Name != "mydb" {
+		t.Errorf("expected db name mydb, got %s", cfg.Database.Name)
+	}
+	if cfg.Database.SSLMode != "require" {
+		t.Errorf("expected sslmode require, got %s", cfg.Database.SSLMode)
+	}
+}

--- a/backend/internal/infrastructure/database/postgres/connection_test.go
+++ b/backend/internal/infrastructure/database/postgres/connection_test.go
@@ -1,0 +1,12 @@
+package postgres
+
+import "testing"
+
+func TestConnect(t *testing.T) {
+	dsn := "postgres://testuser:testpass@localhost/testdb?sslmode=disable"
+	db := Connect(dsn)
+	if err := db.Ping(); err != nil {
+		t.Fatalf("failed to ping db: %v", err)
+	}
+	db.Close()
+}

--- a/backend/internal/interfaces/http/middleware/auth_test.go
+++ b/backend/internal/interfaces/http/middleware/auth_test.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Auth())
+	r.GET("/", func(c *gin.Context) {
+		if val, exists := c.Get("user"); exists {
+			c.String(http.StatusOK, val.(string))
+		} else {
+			c.Status(http.StatusUnauthorized)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "token123")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if body := w.Body.String(); body != "token123" {
+		t.Fatalf("expected body token123, got %s", body)
+	}
+}

--- a/backend/internal/interfaces/http/middleware/cors_test.go
+++ b/backend/internal/interfaces/http/middleware/cors_test.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestCORSHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(CORS())
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Fatalf("missing CORS header")
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCORSOptions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(CORS())
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}

--- a/backend/internal/interfaces/http/middleware/logging_test.go
+++ b/backend/internal/interfaces/http/middleware/logging_test.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestLogging(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer log.SetOutput(orig)
+
+	r := gin.New()
+	r.Use(Logging())
+	r.GET("/ping", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "GET /ping") {
+		t.Fatalf("expected log to contain GET /ping, got %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- test default and env var overrides in config.Load
- test postgres.Connect against a local database
- cover logging, auth, and CORS middleware

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ba1e9cdec832f970dd48546da8af5